### PR TITLE
Add support for Amazon Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Tested on:
 - Centos 7.0
 - Fedora 20
 - Fedora 21
+- Amazon Linux
 
 Should also work on:
 - RHEL 6

--- a/metadata.rb
+++ b/metadata.rb
@@ -8,6 +8,6 @@ version '0.1.7'
 
 supports 'centos'
 supports 'debian'
-supports 'fedora', '<= 21'
+supports 'fedora', '< 22.0'
 supports 'rhel'
 supports 'ubuntu'

--- a/providers/default.rb
+++ b/providers/default.rb
@@ -84,6 +84,23 @@ action :set do
     end
 
     reconfigure.run_action(:run) if tz_f.updated_by_last_action?
+  when 'amazon'
+    tz_f = file '/etc/sysconfig/clock' do
+      owner 'root'
+      group 'root'
+      mode 0644
+      action :nothing
+      content %(ZONE="#{new_resource.timezone}"\n)
+    end
+
+    tz_f.run_action(:create)
+
+    tz_symlink = execute 'symlink-timezone' do
+      command "ln -sf /usr/share/zoneinfo/#{new_resource.timezone} /etc/localtime"
+      action :nothing
+    end
+
+    tz_symlink.run_action(:run) if tz_f.updated_by_last_action?
   end
 
   new_resource.updated_by_last_action(tz_f.updated_by_last_action?)


### PR DESCRIPTION
I've added an additional `when` block to handle Amazon Linux. Also fixed the supported Fedora version in metadata.rb, for some reason it's not in the latest available commit. 
