### PR TITLE
supports 'fedora' needs to have semver for version

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -8,6 +8,6 @@ version '0.1.7'
 
 supports 'centos'
 supports 'debian'
-supports 'fedora', '<= 21'
+supports 'fedora'
 supports 'rhel'
 supports 'ubuntu'


### PR DESCRIPTION
I'm trying to use policy files that reference your master branch.

```
Error: Failed to generate Policyfile.lock
Reason: (Chef::Exceptions::InvalidCookbookVersion) '21' does not match 'x.y.z' or 'x.y'
```

```
# Policyfile.rb - Describe how you want Chef to build your system.
#
# For more information on the Policyfile feature, visit
# https://github.com/opscode/chef-dk/blob/master/POLICYFILE_README.md

# A name that describes what the system you're building with Chef does.
name "tmate_master"

# Where to find external cookbooks:

# run_list: chef-client will run these recipes in the order specified.
run_list "ruby",
         "role[collectd_graphite]",
         "postgresql",
         "tmate_master"

# Specify a custom source for a single cookbook:
# cookbook "example_cookbook", path: "../cookbooks/example_cookbook"
default_source :supermarket

cookbook 'ntp'
cookbook 'graphite',       :github => 'hw-cookbooks/graphite'
cookbook 'collectd',       :github => 'coderanger/chef-collectd'
cookbook 'statsd',         :github => 'hectcastro/chef-statsd'
cookbook 'rvm',            :github => 'fnichol/chef-rvm'
cookbook 'user',           :github => 'fnichol/chef-user'
cookbook 'timezone_lwrp',  :github => 'dragonsmith/chef-timezone'
```
